### PR TITLE
update get_token argument order to match other lib and timestamp optional

### DIFF
--- a/lib/SmileIdentityCore.php
+++ b/lib/SmileIdentityCore.php
@@ -215,10 +215,11 @@ class SmileIdentityCore
 
     /***
      *  Will query the backend for web session token with a specific timestamp
-     * @param timestamp the iso 8601 date/time format to generate the token from
-     * @param user_id
-     * @param job_id
-     * @param product_type - Literal value of any of the 6 product type options
+     * @param $user_id - user's id
+     * @param $job_id - job id
+     * @param $product_type - Literal value of the 6 product type options
+     * @param $timestamp - the iso 8601 date/time format to generate the token from
+     * @param $callback_url - the iso 8601 date/time format to generate the token from
      * @return array
      * @throws GuzzleException
      */

--- a/lib/SmileIdentityCore.php
+++ b/lib/SmileIdentityCore.php
@@ -215,23 +215,25 @@ class SmileIdentityCore
 
     /***
      *  Will query the backend for web session token with a specific timestamp
-     * @param timestamp the timestamp to generate the token from
+     * @param timestamp the iso 8601 date/time format to generate the token from
      * @param user_id
      * @param job_id
      * @param product_type - Literal value of any of the 6 product type options
      * @return array
      * @throws GuzzleException
      */
-    public function get_web_token($timestamp, $user_id, $job_id, $product_type): array
+    public function get_web_token($user_id, $job_id, $product_type, $timestamp = null, $callback_url = null): array
     {
+        $generate_signature = $this->sig_class->generate_signature($timestamp);
+
         $data = array(
-            'timestamp' => date(DateTimeInterface::ISO8601, $timestamp),
-            'callback_url' => $this->default_callback,
+            'callback_url' => $callback_url != null ? $callback_url : $this->default_callback,
             'partner_id' => $this->partner_id,
             'user_id' => $user_id,
             'job_id' => $job_id,
             'product' => $product_type,
-            'signature' => $this->sig_class->generate_signature($timestamp),
+            'signature' => $generate_signature["signature"],
+            'timestamp' => $generate_signature["timestamp"]
         );
 
         $json_data = json_encode($data, JSON_PRETTY_PRINT);

--- a/tests/SmileIdentityCoreTest.php
+++ b/tests/SmileIdentityCoreTest.php
@@ -364,12 +364,12 @@ final class SmileIdentityCoreTest extends TestCase
         $handler = HandlerStack::create($mock);
         $client = new Client(['handler' => $handler]);
         $this->sic->setClient($client);
-        
+
         $timestamp = Clock::now()->getTimestamp();
         $user_id = "<USER_ID>";
         $job_id = "<JOB_ID>";
         $product = "<PRODUCT_TYPE>";
-        $result = $this->sic->get_web_token($timestamp, $user_id, $job_id, $product);
+        $result = $this->sic->get_web_token($user_id, $job_id, $product, $timestamp);
         $this->assertEquals($result, $expectedResult);
     }
     


### PR DESCRIPTION
This PR introduces a breaking change and should be deployed alongside https://github.com/smileidentity/smile-identity-core-php/pull/8