### PR TITLE
Update SmileIdentityCore.php

### DIFF
--- a/lib/SmileIdentityCore.php
+++ b/lib/SmileIdentityCore.php
@@ -97,6 +97,7 @@ class SmileIdentityCore
             JobType::BIOMETRIC_KYC,
             JobType::DOCUMENT_VERIFICATION,
             JobType::SMART_SELFIE_AUTHENTICATION,
+            JobType::SMART_SELFIE_REGISTRATION,
             JobType::BUSINESS_VERIFICATION
         ), $job_type);
 

--- a/tests/SmileIdentityCoreTest.php
+++ b/tests/SmileIdentityCoreTest.php
@@ -464,6 +464,7 @@ final class SmileIdentityCoreTest extends TestCase
             JobType::BIOMETRIC_KYC,
             JobType::DOCUMENT_VERIFICATION,
             JobType::SMART_SELFIE_AUTHENTICATION,
+            JobType::SMART_SELFIE_REGISTRATION,
             JobType::BUSINESS_VERIFICATION
         ));
         $this->expectException(Exception::class);


### PR DESCRIPTION
The current SDK does not allow for the submission of `SMART_SELFIE_REGISTRATION` jobs due to the `validateJobTypes()` method call not having the job_type for registration in the array list. The `InvalidArgumentException` **"job_type must be one of 1, 6, 2, 7"** is thrown since `job_type` for registration is `4`