### PR TITLE
Update Test Workflow to Use $GITHUB_ENV for Environment Variables

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,11 +19,11 @@ jobs:
         php-version: ${{ matrix.php-version }}
     - name: Get composer cache directory
       id: composer-cache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      run: echo "COMPOSER_CACHE_DIR=$(composer config cache-files-dir)" >> $GITHUB_ENV
     - name: Cache dependencies
       uses: actions/cache@v4
       with:
-        path: ${{ steps.composer-cache.outputs.dir }}
+        path: ${{ env.COMPOSER_CACHE_DIR }}
         key: ${{ runner.os }}-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
         restore-keys: ${{ runner.os }}-${{ matrix.php-version }}-composer-
     - name: Install dependencies


### PR DESCRIPTION
This PR updates the GitHub Actions test workflow to replace the deprecated `::set-output` command with the new `$GITHUB_ENV` method for setting environment variables. 