### PR TITLE
update domain name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2022 Smile Identity, https://github.com/smileidentity/smile-identity-core-php <info@smileidentity.com>
+Copyright (c) 2022 Smile Identity, https://github.com/smileidentity/smile-identity-core-php <info@usesmileid.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	"authors": [
 		{
 			"name": "Smile Identity",
-			"email": "support@smileidentity.com"
+			"email": "support@usesmileid.com"
 		}
 	],
 	"require": {

--- a/examples/biometric_kyc.php
+++ b/examples/biometric_kyc.php
@@ -7,7 +7,7 @@ use SmileIdentity\SmileIdentityCore;
 // Autoload the dependencies
 require 'vendor/autoload.php';
 
-// See https://docs.smileidentity.com/server-to-server/php/products/biometric-kyc for
+// See https://docs.usesmileid.com/server-to-server/php/products/biometric-kyc for
 // how to setup and retrieve configuation values for the SmileIdentityCore class.
 
 $partner_id = '<Put your partner ID here>';

--- a/examples/business_verification.php
+++ b/examples/business_verification.php
@@ -6,7 +6,7 @@ use SmileIdentity\SmileIdentityCore;
 // Autoload the dependencies
 require 'vendor/autoload.php';
 
-// See https://docs.smileidentity.com/products/for-businesses-kyb/business-verification for
+// See https://docs.usesmileid.com/products/for-businesses-kyb/business-verification for
 // more information on business verification
 
 $partner_id = '<Put your partner ID here>';

--- a/examples/document_verification.php
+++ b/examples/document_verification.php
@@ -7,7 +7,7 @@ use SmileIdentity\SmileIdentityCore;
 // Autoload the dependencies
 require 'vendor/autoload.php';
 
-// See https://docs.smileidentity.com/server-to-server/php/products/document-verification for
+// See https://docs.usesmileid.com/server-to-server/php/products/document-verification for
 // how to setup and retrieve configuation values for the SmileIdentityCore class.
 
 $partner_id = '<Put your partner ID here>';

--- a/examples/enhanced_document_verification.php
+++ b/examples/enhanced_document_verification.php
@@ -7,7 +7,7 @@ use SmileIdentity\SmileIdentityCore;
 // Autoload the dependencies
 require 'vendor/autoload.php';
 
-// See https://docs.smileidentity.com/server-to-server/php/products/document-verification for
+// See https://docs.usesmileid.com/server-to-server/php/products/document-verification for
 // how to setup and retrieve configuation values for the SmileIdentityCore class.
 
 $partner_id = '<Put your partner ID here>';

--- a/examples/enhanced_kyc.php
+++ b/examples/enhanced_kyc.php
@@ -6,7 +6,7 @@ use SmileIdentity\JobType;
 // Autoload the dependencies
 require 'vendor/autoload.php';
 
-// See https://docs.smileidentity.com/server-to-server/php/products/enhanced-kyc for
+// See https://docs.usesmileid.com/server-to-server/php/products/enhanced-kyc for
 // how to setup and retrieve configuation values for the IdApi class.
 
 $partner_id = '<Put your partner ID here>';

--- a/examples/smart_selfie_authentication.php
+++ b/examples/smart_selfie_authentication.php
@@ -7,7 +7,7 @@ use SmileIdentity\SmileIdentityCore;
 // Autoload the dependencies
 require 'vendor/autoload.php';
 
-// See https://docs.smileidentity.com/server-to-server/php/products/smartselfie-tm-authentication for
+// See https://docs.usesmileid.com/server-to-server/php/products/smartselfie-tm-authentication for
 // how to setup and retrieve configuation values for the SmileIdentityCore class.
 
 $partner_id = '<Put your partner ID here>';


### PR DESCRIPTION
This PR updates smileidentity.com to usesmileid.com as part of the gradual transition to using the new domain name throughout the system.