### PR TITLE
Import Semgrep results into DefectDojo

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -32,6 +32,31 @@ jobs:
         with:
           sarif_file: semgrep.sarif
 
+      - name: Import results into DefectDojo
+        if: always()
+        continue-on-error: true
+        env:
+          DEFECTDOJO_URL: ${{ secrets.DEFECTDOJO_URL }}
+          DEFECTDOJO_API_TOKEN: ${{ secrets.DEFECTDOJO_API_TOKEN }}
+        run: |
+          if [ ! -s semgrep.sarif ]; then
+            echo "No semgrep.sarif file found, skipping DefectDojo import"
+            exit 0
+          fi
+          curl -sS -f \
+            -H "Authorization: Token ${DEFECTDOJO_API_TOKEN}" \
+            -F "scan_type=SARIF" \
+            -F "file=@semgrep.sarif" \
+            -F "product_type_name=GitHub" \
+            -F "product_name=${{ github.event.repository.name }}" \
+            -F "engagement_name=CI" \
+            -F "auto_create_context=true" \
+            -F "close_old_findings=true" \
+            -F "deduplication_on_engagement=true" \
+            -F "commit_hash=${{ github.sha }}" \
+            -F "branch_tag=${{ github.head_ref || github.ref_name }}" \
+            "${DEFECTDOJO_URL}/api/v2/reimport-scan/"
+
       - name: Comment findings on PR
         if: github.event_name == 'pull_request' && always()
         env:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -38,6 +38,8 @@ jobs:
         env:
           DEFECTDOJO_URL: ${{ secrets.DEFECTDOJO_URL }}
           DEFECTDOJO_API_TOKEN: ${{ secrets.DEFECTDOJO_API_TOKEN }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          BRANCH_TAG: ${{ github.head_ref || github.ref_name }}
         run: |
           if [ ! -s semgrep.sarif ]; then
             echo "No semgrep.sarif file found, skipping DefectDojo import"
@@ -48,13 +50,13 @@ jobs:
             -F "scan_type=SARIF" \
             -F "file=@semgrep.sarif" \
             -F "product_type_name=GitHub" \
-            -F "product_name=${{ github.event.repository.name }}" \
+            -F "product_name=${REPO_NAME}" \
             -F "engagement_name=CI" \
             -F "auto_create_context=true" \
             -F "close_old_findings=true" \
             -F "deduplication_on_engagement=true" \
             -F "commit_hash=${{ github.sha }}" \
-            -F "branch_tag=${{ github.head_ref || github.ref_name }}" \
+            -F "branch_tag=${BRANCH_TAG}" \
             "${DEFECTDOJO_URL}/api/v2/reimport-scan/"
 
       - name: Comment findings on PR


### PR DESCRIPTION
### **User description**
## Summary

Pushes Semgrep SARIF results into [DefectDojo](https://defectdojo.smile.id) so findings get an aggregated, historical view instead of only living in PR checks / GitHub Code Scanning.

- Adds an "Import results into DefectDojo" step after the existing "Upload SARIF to GitHub Security" step (before the "Comment findings on PR" step) — no change to the `semgrep scan` invocation itself.
- SARIF filename in this repo's workflow: **`semgrep.sarif`** (produced by `semgrep scan --config p/security-audit --sarif -o semgrep.sarif`) — same filename as the lambda template, so no path adjustment was needed. Please sanity-check this against the actual workflow run.
- Uses DefectDojo's generic SARIF parser via `/api/v2/reimport-scan/` with `auto_create_context=true`, so the Product Type / Product / Engagement chain (`GitHub` / `smile-identity-core-php` / `CI`) is created on first run and reused (deduplicated) on every run after.
- Non-blocking: `continue-on-error: true`, `if: always()`, and skips cleanly if `semgrep.sarif` wasn't produced or is empty.
- Uses the already-provisioned org-wide `DEFECTDOJO_URL` / `DEFECTDOJO_API_TOKEN` secrets (no secrets were created/modified by this PR).

This mirrors smileidentity/lambda#4662, which is currently **open (not yet merged)** but has a proven working pull_request-triggered CI run for the same step.

## Test plan

- [ ] Run this workflow (via this PR's own CI) and confirm the "Import results into DefectDojo" step succeeds
- [ ] Confirm a Product `smile-identity-core-php` under Product Type `GitHub` appears in DefectDojo with a `CI` engagement and findings matching `semgrep.sarif`
- [ ] Re-run the workflow and confirm findings are deduplicated/reimported into the same engagement rather than creating a duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add DefectDojo import step for Semgrep SARIF results

- Uses reimport-scan API with auto-created product/engagement context

- Non-blocking with graceful skip when SARIF is missing

- Enables historical finding tracking and deduplication


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Semgrep Scan"] --> B["Upload SARIF to GitHub Security"]
  B --> C["Import results into DefectDojo"]
  C --> D["Comment findings on PR"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>semgrep.yml</strong><dd><code>Add DefectDojo reimport step to Semgrep workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/semgrep.yml

<ul><li>Added a new "Import results into DefectDojo" step after the GitHub <br>SARIF upload<br> <li> Uses <code>curl</code> to POST <code>semgrep.sarif</code> to DefectDojo's <code>/api/v2/reimport-scan/</code> <br>endpoint<br> <li> Configures auto-creation of Product Type (<code>GitHub</code>), Product (repo <br>name), and Engagement (<code>CI</code>)<br> <li> Includes deduplication, old-finding closure, commit hash, and branch <br>metadata</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-php/pull/46/files#diff-943c91ac8e5085136f071a01d6ad70ffe7beefb141dd4d45c3fc75c52c3c9dbb">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>